### PR TITLE
Random.nextInt() may return negative value.This will cause GRPCChannelManager stop.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/boot/DefaultNamedThreadFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/boot/DefaultNamedThreadFactory.java
@@ -32,8 +32,7 @@ public class DefaultNamedThreadFactory implements ThreadFactory {
     }
     @Override
     public Thread newThread(Runnable r) {
-        Thread t = new Thread();
-        t.setName(namePrefix + threadSeq.getAndIncrement());
+        Thread t = new Thread(null, r,namePrefix + threadSeq.getAndIncrement(),0);
         t.setDaemon(true);
         return t;
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/boot/DefaultNamedThreadFactory.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/boot/DefaultNamedThreadFactory.java
@@ -32,7 +32,7 @@ public class DefaultNamedThreadFactory implements ThreadFactory {
     }
     @Override
     public Thread newThread(Runnable r) {
-        Thread t = new Thread(null, r,namePrefix + threadSeq.getAndIncrement(),0);
+        Thread t = new Thread(r,namePrefix + threadSeq.getAndIncrement());
         t.setDaemon(true);
         return t;
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/AppAndServiceRegisterClient.java
@@ -106,6 +106,7 @@ public class AppAndServiceRegisterClient implements BootService, GRPCChannelList
 
     @Override
     public void run() {
+        logger.debug("AppAndServiceRegisterClient running, status:{}.",status);
         boolean shouldTry = true;
         while (CONNECTED.equals(status) && shouldTry) {
             shouldTry = false;

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -33,11 +33,10 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.skywalking.apm.agent.core.boot.BootService;
 import org.skywalking.apm.agent.core.boot.DefaultNamedThreadFactory;
+import org.skywalking.apm.agent.core.conf.Config;
 import org.skywalking.apm.agent.core.conf.RemoteDownstreamConfig;
 import org.skywalking.apm.logging.ILog;
 import org.skywalking.apm.logging.LogManager;
-
-import static org.skywalking.apm.agent.core.conf.Config.Collector.GRPC_CHANNEL_CHECK_INTERVAL;
 
 /**
  * @author wusheng
@@ -60,7 +59,7 @@ public class GRPCChannelManager implements BootService, Runnable {
     public void boot() throws Throwable {
         connectCheckFuture = Executors
             .newSingleThreadScheduledExecutor(new DefaultNamedThreadFactory("GRPCChannelManager"))
-            .scheduleAtFixedRate(this, 0, GRPC_CHANNEL_CHECK_INTERVAL, TimeUnit.SECONDS);
+            .scheduleAtFixedRate(this, 0, Config.Collector.GRPC_CHANNEL_CHECK_INTERVAL, TimeUnit.SECONDS);
     }
 
     @Override
@@ -72,10 +71,12 @@ public class GRPCChannelManager implements BootService, Runnable {
     public void shutdown() throws Throwable {
         connectCheckFuture.cancel(true);
         managedChannel.shutdownNow();
+        logger.debug("Selected collector grpc service shutdown.");
     }
 
     @Override
     public void run() {
+        logger.debug("Selected collector grpc service running, reconnect:{}.",reconnect);
         if (reconnect) {
             if (RemoteDownstreamConfig.Collector.GRPC_SERVERS.size() > 0) {
                 int index = random.nextInt() % RemoteDownstreamConfig.Collector.GRPC_SERVERS.size();
@@ -101,7 +102,7 @@ public class GRPCChannelManager implements BootService, Runnable {
                 }
             }
 
-            logger.debug("Selected collector grpc service is not available. Wait {} seconds to retry", GRPC_CHANNEL_CHECK_INTERVAL);
+            logger.debug("Selected collector grpc service is not available. Wait {} seconds to retry", Config.Collector.GRPC_CHANNEL_CHECK_INTERVAL);
         }
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -79,9 +79,10 @@ public class GRPCChannelManager implements BootService, Runnable {
         logger.debug("Selected collector grpc service running, reconnect:{}.",reconnect);
         if (reconnect) {
             if (RemoteDownstreamConfig.Collector.GRPC_SERVERS.size() > 0) {
-                int index = random.nextInt() % RemoteDownstreamConfig.Collector.GRPC_SERVERS.size();
-                String server = RemoteDownstreamConfig.Collector.GRPC_SERVERS.get(index);
+                String server = "";
                 try {
+                    int index = Math.abs(random.nextInt()) % RemoteDownstreamConfig.Collector.GRPC_SERVERS.size();
+                    server = RemoteDownstreamConfig.Collector.GRPC_SERVERS.get(index);
                     String[] ipAndPort = server.split(":");
                     ManagedChannelBuilder<?> channelBuilder =
                         NettyChannelBuilder.forAddress(ipAndPort[0], Integer.parseInt(ipAndPort[1]))


### PR DESCRIPTION
1.修复了上次提交的pr的bug,会导致代理的定时任务不执行，非常抱歉。
2.之前一直发现代理注册不到collector,没法发送样本，发现是GRPCChannelManager执行几次后暂停了，通过导出堆快照知道报了IndexOutOfBoundsException异常，已找到问题代码并修复。