### PR TITLE
change: let nutz-mvc-plugin compatible with servlet 2.5

### DIFF
--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -119,6 +119,12 @@
             <artifactId>apm-datacarrier</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+        	<groupId>javax.servlet</groupId>
+        	<artifactId>javax.servlet-api</artifactId>
+        	<version>3.1.0</version>
+        	<scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/tool/ServletApiTool.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/tool/ServletApiTool.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+
+package org.skywalking.apm.agent.core.tool;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author wendal
+ *
+ */
+public class ServletApiTool {
+
+    // HttpServletResponse.getStatus() is available since Servlet API 3.0
+    protected static boolean RGSA;
+    protected static boolean INITED;
+    
+    public static boolean isResponseGetStatusAvailable() {
+        if (!INITED) {
+            try {
+                HttpServletResponse.class.getMethod("getStatus");
+                RGSA = true;
+            } catch (Throwable e) {
+            }
+            INITED = true;
+        }
+        return RGSA;
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/src/main/java/org/skywalking/apm/plugin/nutz/mvc/ActionMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/src/main/java/org/skywalking/apm/plugin/nutz/mvc/ActionMethodInterceptor.java
@@ -32,6 +32,7 @@ import org.skywalking.apm.agent.core.context.trace.SpanLayer;
 import org.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.skywalking.apm.agent.core.tool.ServletApiTool;
 import org.skywalking.apm.network.trace.component.ComponentsDefine;
 
 /**
@@ -40,6 +41,7 @@ import org.skywalking.apm.network.trace.component.ComponentsDefine;
  * @author wendal
  */
 public class ActionMethodInterceptor implements InstanceMethodsAroundInterceptor {
+    
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         MethodInterceptResult result) throws Throwable {
@@ -76,7 +78,7 @@ public class ActionMethodInterceptor implements InstanceMethodsAroundInterceptor
         HttpServletResponse response = Mvcs.getResp();
 
         AbstractSpan span = ContextManager.activeSpan();
-        if (response.getStatus() >= 400) {
+        if (ServletApiTool.isResponseGetStatusAvailable() && response.getStatus() >= 400) {
             span.errorOccurred();
             Tags.STATUS_CODE.set(span, Integer.toString(response.getStatus()));
         }


### PR DESCRIPTION
Some of our server are running by jetty7/tomcat6, which is provide Servlet API 2.5 without "HttpServletResponse.getStatus()" method.