### PR TITLE
spring mvc-annotation -3.x not work

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
@@ -36,13 +36,13 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>3.2.18.RELEASE</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>3.2.18.RELEASE</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
@@ -36,13 +36,13 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>4.3.10.RELEASE</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>4.3.8.RELEASE</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/main/java/org/skywalking/apm/plugin/spring/mvc/v4/define/AbstractControllerInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/main/java/org/skywalking/apm/plugin/spring/mvc/v4/define/AbstractControllerInstrumentation.java
@@ -35,10 +35,10 @@ import static org.skywalking.apm.agent.core.plugin.match.ClassAnnotationMatch.by
  * <code>org.springframework.web.bind.annotation.RequestMapping</code> that class has
  * <code>org.springframework.stereotype.Controller</code> annotation.
  *
- * <code>org.skywalking.apm.plugin.spring.mvc.ControllerConstructorInterceptor</code> set the controller base path to
+ * <code>org.skywalking.apm.plugin.spring.mvc.v4.ControllerConstructorInterceptor</code> set the controller base path to
  * dynamic field before execute constructor.
  *
- * <code>org.skywalking.apm.plugin.spring.mvc.RequestMappingMethodInterceptor</code> get the request path from
+ * <code>org.skywalking.apm.plugin.spring.mvc.v4.RequestMappingMethodInterceptor</code> get the request path from
  * dynamic field first, if not found, <code>RequestMappingMethodInterceptor</code> generate request path  that
  * combine the path value of current annotation on current method and the base path and set the new path to the dynamic
  * filed
@@ -57,7 +57,7 @@ public abstract class AbstractControllerInstrumentation extends ClassInstanceMet
 
                 @Override
                 public String getConstructorInterceptor() {
-                    return "org.skywalking.apm.plugin.spring.mvc.ControllerConstructorInterceptor";
+                    return "org.skywalking.apm.plugin.spring.mvc.v4.ControllerConstructorInterceptor";
                 }
             }
         };
@@ -74,7 +74,7 @@ public abstract class AbstractControllerInstrumentation extends ClassInstanceMet
 
                 @Override
                 public String getMethodsInterceptor() {
-                    return "org.skywalking.apm.plugin.spring.mvc.RequestMappingMethodInterceptor";
+                    return "org.skywalking.apm.plugin.spring.mvc.v4.RequestMappingMethodInterceptor";
                 }
 
                 @Override
@@ -94,7 +94,7 @@ public abstract class AbstractControllerInstrumentation extends ClassInstanceMet
 
                 @Override
                 public String getMethodsInterceptor() {
-                    return "org.skywalking.apm.plugin.spring.mvc.RestMappingMethodInterceptor";
+                    return "org.skywalking.apm.plugin.spring.mvc.v4.RestMappingMethodInterceptor";
                 }
 
                 @Override

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/skywalking/apm/plugin/spring/mvc/v4/define/ControllerInstrumentationTest.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/skywalking/apm/plugin/spring/mvc/v4/define/ControllerInstrumentationTest.java
@@ -52,8 +52,8 @@ public class ControllerInstrumentationTest {
     public void testGetInstanceMethodsInterceptPoints() throws Throwable {
         InstanceMethodsInterceptPoint[] methodPoints = controllerInstrumentation.getInstanceMethodsInterceptPoints();
         assertThat(methodPoints.length, is(2));
-        assertThat(methodPoints[0].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.RequestMappingMethodInterceptor"));
-        assertThat(methodPoints[1].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.RestMappingMethodInterceptor"));
+        assertThat(methodPoints[0].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.v4.RequestMappingMethodInterceptor"));
+        assertThat(methodPoints[1].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.v4.RestMappingMethodInterceptor"));
 
         Assert.assertFalse(methodPoints[0].isOverrideArgs());
         Assert.assertFalse(methodPoints[1].isOverrideArgs());
@@ -70,7 +70,7 @@ public class ControllerInstrumentationTest {
         ConstructorInterceptPoint cip = cips[0];
         Assert.assertNotNull(cip);
 
-        Assert.assertEquals(cip.getConstructorInterceptor(), "org.skywalking.apm.plugin.spring.mvc.ControllerConstructorInterceptor");
+        Assert.assertEquals(cip.getConstructorInterceptor(), "org.skywalking.apm.plugin.spring.mvc.v4.ControllerConstructorInterceptor");
         Assert.assertTrue(cip.getConstructorMatcher().equals(ElementMatchers.any()));
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/skywalking/apm/plugin/spring/mvc/v4/define/RestControllerInstrumentationTest.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/skywalking/apm/plugin/spring/mvc/v4/define/RestControllerInstrumentationTest.java
@@ -50,8 +50,8 @@ public class RestControllerInstrumentationTest {
     public void testGetInstanceMethodsInterceptPoints() throws Throwable {
         InstanceMethodsInterceptPoint[] methodPoints = restControllerInstrumentation.getInstanceMethodsInterceptPoints();
         assertThat(methodPoints.length, is(2));
-        assertThat(methodPoints[0].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.RequestMappingMethodInterceptor"));
-        assertThat(methodPoints[1].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.RestMappingMethodInterceptor"));
+        assertThat(methodPoints[0].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.v4.RequestMappingMethodInterceptor"));
+        assertThat(methodPoints[1].getMethodsInterceptor(), is("org.skywalking.apm.plugin.spring.mvc.v4.RestMappingMethodInterceptor"));
 
         Assert.assertFalse(methodPoints[0].isOverrideArgs());
         Assert.assertFalse(methodPoints[1].isOverrideArgs());


### PR DESCRIPTION
* The package name of interceptors are wrong. Missing the `v3` package name.
* The dependency type should be `provided`.

There two trigger agent can't work with spring 4.