### PR TITLE
support for logback MDC

### DIFF
--- a/apm-application-toolkit/apm-toolkit-logback-1.x/src/main/java/org/skywalking/apm/toolkit/log/logback/v1/x/mdc/LogbackMDCPatternConverter.java
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/src/main/java/org/skywalking/apm/toolkit/log/logback/v1/x/mdc/LogbackMDCPatternConverter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+
+package org.skywalking.apm.toolkit.log.logback.v1.x.mdc;
+
+import ch.qos.logback.classic.pattern.MDCConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.util.OptionHelper;
+
+/**
+ * @author zhangkewei
+ */
+public class LogbackMDCPatternConverter extends MDCConverter {
+    private static final  String CONVERT_KEY = "tid";
+
+    private boolean convert4TID = false;
+    @Override
+    public void start() {
+        super.start();
+        String[] key = OptionHelper.extractDefaultReplacement(getFirstOption());
+        if (null != key && key.length > 0 && CONVERT_KEY.equals(key[0])) {
+            convert4TID = true;
+        }
+    }
+    @Override
+    public String convert(ILoggingEvent iLoggingEvent) {
+        return convert4TID ? convertTID() : super.convert(iLoggingEvent);
+    }
+
+    public String convertTID() {
+        return "TID: N/A";
+    }
+}

--- a/apm-application-toolkit/apm-toolkit-logback-1.x/src/main/java/org/skywalking/apm/toolkit/log/logback/v1/x/mdc/TraceIdMDCPatternLogbackLayout.java
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/src/main/java/org/skywalking/apm/toolkit/log/logback/v1/x/mdc/TraceIdMDCPatternLogbackLayout.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+
+package org.skywalking.apm.toolkit.log.logback.v1.x.mdc;
+
+import ch.qos.logback.classic.PatternLayout;
+
+/**
+ * Override "X",SuperClass run before Subclass.
+ * @author zhangkewei
+ */
+public class TraceIdMDCPatternLogbackLayout extends PatternLayout {
+    static {
+        defaultConverterMap.put("X", LogbackMDCPatternConverter.class.getName());
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/java/org/skywalking/apm/toolkit/activation/log/logback/v1/x/mdc/MDCConverterActivation.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/java/org/skywalking/apm/toolkit/activation/log/logback/v1/x/mdc/MDCConverterActivation.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+package org.skywalking.apm.toolkit.activation.log.logback.v1.x.mdc;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
+
+/**
+ * Support MDC https://logback.qos.ch/manual/mdc.html
+ * @author: zhangkewei
+ */
+public class MDCConverterActivation extends ClassInstanceMethodsEnhancePluginDefine {
+
+    @Override
+    protected ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return null;
+    }
+
+    @Override
+    protected InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[] {
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("convertTID");
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return "org.skywalking.apm.toolkit.activation.log.logback.v1.x.mdc.PrintMDCTraceIdInterceptor";
+                }
+
+                @Override public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byName("org.skywalking.apm.toolkit.log.logback.v1.x.mdc.LogbackMDCPatternConverter");
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/java/org/skywalking/apm/toolkit/activation/log/logback/v1/x/mdc/PrintMDCTraceIdInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/java/org/skywalking/apm/toolkit/activation/log/logback/v1/x/mdc/PrintMDCTraceIdInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+package org.skywalking.apm.toolkit.activation.log.logback.v1.x.mdc;
+
+import org.skywalking.apm.agent.core.context.ContextManager;
+import org.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
+import org.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author zhangkewei
+ */
+public class PrintMDCTraceIdInterceptor implements InstanceMethodsAroundInterceptor {
+    @Override public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments,
+        Class<?>[] argumentsTypes, MethodInterceptResult result) throws Throwable {
+
+    }
+
+    @Override public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments,
+        Class<?>[] argumentsTypes, Object ret) throws Throwable {
+        return "TID:" + ContextManager.getGlobalTraceId();
+    }
+
+    @Override public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+        Class<?>[] argumentsTypes, Throwable t) {
+
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/src/main/resources/skywalking-plugin.def
@@ -1,1 +1,2 @@
 toolkit-logback=org.skywalking.apm.toolkit.activation.log.logback.v1.x.LogbackPatternConverterActivation
+toolkit-logback=org.skywalking.apm.toolkit.activation.log.logback.v1.x.mdc.MDCConverterActivation


### PR DESCRIPTION
- logback.xml配置

> 增加%X{tid}
例子:
```
<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <layout class="org.skywalking.apm.toolkit.log.logback.v1.x.mdc.TraceIdMDCPatternLogbackLayout">
            <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS}  %X{tid} %-5level %logger{36} -%msg%n</Pattern>
     </layout>
</appender>
```