### PR TITLE
AgentStream NullPointerException with RemoteWorker

### DIFF
--- a/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/node/component/NodeComponentSpanListener.java
+++ b/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/node/component/NodeComponentSpanListener.java
@@ -60,6 +60,7 @@ public class NodeComponentSpanListener implements EntrySpanListener, ExitSpanLis
         }
 
         nodeComponent.setPeerId(spanDecorator.getPeerId());
+        nodeComponent.setPeer(Const.EMPTY_STRING);
         id = id + Const.ID_SPLIT + nodeComponent.getPeerId();
         nodeComponent.setId(id);
         nodeComponents.add(nodeComponent);
@@ -81,6 +82,7 @@ public class NodeComponentSpanListener implements EntrySpanListener, ExitSpanLis
         }
 
         nodeComponent.setPeerId(applicationId);
+        nodeComponent.setPeer(Const.EMPTY_STRING);
         id = id + Const.ID_SPLIT + String.valueOf(applicationId);
         nodeComponent.setId(id);
 

--- a/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/node/mapping/NodeMappingSpanListener.java
+++ b/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/node/mapping/NodeMappingSpanListener.java
@@ -51,6 +51,7 @@ public class NodeMappingSpanListener implements RefsListener, FirstSpanListener 
         NodeMappingDataDefine.NodeMapping nodeMapping = new NodeMappingDataDefine.NodeMapping();
         nodeMapping.setApplicationId(applicationId);
         nodeMapping.setAddressId(referenceDecorator.getNetworkAddressId());
+        nodeMapping.setAddress(Const.EMPTY_STRING);
         String id = String.valueOf(applicationId) + Const.ID_SPLIT + String.valueOf(nodeMapping.getAddressId());
         nodeMapping.setId(id);
         nodeMappings.add(nodeMapping);

--- a/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/noderef/NodeReferenceSpanListener.java
+++ b/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/noderef/NodeReferenceSpanListener.java
@@ -53,6 +53,7 @@ public class NodeReferenceSpanListener implements EntrySpanListener, ExitSpanLis
         NodeReferenceDataDefine.NodeReference nodeReference = new NodeReferenceDataDefine.NodeReference();
         nodeReference.setFrontApplicationId(applicationId);
         nodeReference.setBehindApplicationId(spanDecorator.getPeerId());
+        nodeReference.setBehindPeer(Const.EMPTY_STRING);
         nodeReference.setTimeBucket(TimeBucketUtils.INSTANCE.getMinuteTimeBucket(spanDecorator.getStartTime()));
 
         StringBuilder idBuilder = new StringBuilder();
@@ -79,6 +80,7 @@ public class NodeReferenceSpanListener implements EntrySpanListener, ExitSpanLis
             NodeReferenceDataDefine.NodeReference nodeReference = new NodeReferenceDataDefine.NodeReference();
             nodeReference.setFrontApplicationId(Const.USER_ID);
             nodeReference.setBehindApplicationId(applicationId);
+            nodeReference.setBehindPeer(Const.EMPTY_STRING);
             nodeReference.setTimeBucket(TimeBucketUtils.INSTANCE.getMinuteTimeBucket(spanDecorator.getStartTime()));
 
             String idBuilder = String.valueOf(nodeReference.getTimeBucket()) + Const.ID_SPLIT + nodeReference.getFrontApplicationId() +
@@ -96,6 +98,7 @@ public class NodeReferenceSpanListener implements EntrySpanListener, ExitSpanLis
         NodeReferenceDataDefine.NodeReference referenceSum = new NodeReferenceDataDefine.NodeReference();
         referenceSum.setFrontApplicationId(parentApplicationId);
         referenceSum.setBehindApplicationId(applicationId);
+        referenceSum.setBehindPeer(Const.EMPTY_STRING);
         references.add(referenceSum);
     }
 

--- a/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/serviceref/ServiceReferenceSpanListener.java
+++ b/apm-collector/apm-collector-agentstream/src/main/java/org/skywalking/apm/collector/agentstream/worker/serviceref/ServiceReferenceSpanListener.java
@@ -127,12 +127,15 @@ public class ServiceReferenceSpanListener implements FirstSpanListener, EntrySpa
 
         idBuilder.append(entryServiceId).append(Const.ID_SPLIT);
         serviceReference.setEntryServiceId(entryServiceId);
+        serviceReference.setEntryServiceName(Const.EMPTY_STRING);
 
         idBuilder.append(frontServiceId).append(Const.ID_SPLIT);
         serviceReference.setFrontServiceId(frontServiceId);
+        serviceReference.setFrontServiceName(Const.EMPTY_STRING);
 
         idBuilder.append(behindServiceId);
         serviceReference.setBehindServiceId(behindServiceId);
+        serviceReference.setBehindServiceName(Const.EMPTY_STRING);
 
         serviceReference.setId(idBuilder.toString());
         serviceReference.setTimeBucket(timeBucket);


### PR DESCRIPTION
3.2.3中增加了SegmentStandardizationWorker用于校验Segment，缺失信息的样本会被丢弃，所以一些默认值判断、赋值就给去掉了。但是在多于一个collector的集群中会存在均衡负载的逻辑，在RemoteMessage通过GRPC序列化传输的时候，默认值为NULL的字段导致报错。