### PR TITLE
Output all instrumented classes into physical files.

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/conf/Config.java
@@ -54,8 +54,8 @@ public class Config {
         public static int SPAN_LIMIT_PER_SEGMENT = 300;
 
         /**
-         * If true, skywalking agent will save all instrumented classes files. And you can send them to skywalking team,
-         * in order to resolve compatible problem.
+         * If true, skywalking agent will save all instrumented classes files in `/debugging` folder.
+         * Skywalking team may ask for these files in order to resolve compatible problem.
          */
         public static boolean IS_OPEN_DEBUGGING_CLASS = false;
     }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/conf/Config.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/conf/Config.java
@@ -52,6 +52,12 @@ public class Config {
          * memory cost estimated.
          */
         public static int SPAN_LIMIT_PER_SEGMENT = 300;
+
+        /**
+         * If true, skywalking agent will save all instrumented classes files. And you can send them to skywalking team,
+         * in order to resolve compatible problem.
+         */
+        public static boolean IS_OPEN_DEBUGGING_CLASS = false;
     }
 
     public static class Collector {

--- a/apm-sniffer/apm-agent/src/main/java/org/skywalking/apm/agent/InstrumentDebuggingClass.java
+++ b/apm-sniffer/apm-agent/src/main/java/org/skywalking/apm/agent/InstrumentDebuggingClass.java
@@ -19,7 +19,6 @@
 package org.skywalking.apm.agent;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
@@ -59,30 +58,10 @@ public enum InstrumentDebuggingClass {
                     }
                 }
 
-                File newClassFileFolder = new File(debuggingClassesRootPath, typeDescription.getPackage().getActualName().replaceAll("\\.", "/"));
-                if (!newClassFileFolder.exists()) {
-                    newClassFileFolder.mkdirs();
-                }
-                File newClassFile = new File(newClassFileFolder, typeDescription.getSimpleName() + ".class");
-                FileOutputStream fos = null;
                 try {
-                    if (newClassFile.exists()) {
-                        newClassFile.delete();
-                    }
-                    newClassFile.createNewFile();
-                    fos = new FileOutputStream(newClassFile);
-                    fos.write(dynamicType.getBytes());
-                    fos.flush();
+                    dynamicType.saveIn(debuggingClassesRootPath);
                 } catch (IOException e) {
                     logger.error(e, "Can't save class {} to file." + typeDescription.getActualName());
-                } finally {
-                    if (fos != null) {
-                        try {
-                            fos.close();
-                        } catch (IOException e) {
-
-                        }
-                    }
                 }
             } catch (Throwable t) {
                 logger.error(t, "Save debugging classes fail.");

--- a/apm-sniffer/apm-agent/src/main/java/org/skywalking/apm/agent/InstrumentDebuggingClass.java
+++ b/apm-sniffer/apm-agent/src/main/java/org/skywalking/apm/agent/InstrumentDebuggingClass.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+
+package org.skywalking.apm.agent;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import org.skywalking.apm.agent.core.boot.AgentPackageNotFoundException;
+import org.skywalking.apm.agent.core.boot.AgentPackagePath;
+import org.skywalking.apm.agent.core.conf.Config;
+import org.skywalking.apm.agent.core.logging.api.ILog;
+import org.skywalking.apm.agent.core.logging.api.LogManager;
+
+/**
+ * @author wu-sheng
+ */
+public enum InstrumentDebuggingClass {
+    INSTANCE;
+
+    private static final ILog logger = LogManager.getLogger(InstrumentDebuggingClass.class);
+    private File debuggingClassesRootPath;
+
+    public void log(TypeDescription typeDescription, DynamicType dynamicType) {
+        if (!Config.Agent.IS_OPEN_DEBUGGING_CLASS) {
+            return;
+        }
+
+        /**
+         * try to do I/O things in synchronized way, to avoid unexpected situations.
+         */
+        synchronized (INSTANCE) {
+            try {
+                if (debuggingClassesRootPath == null) {
+                    try {
+                        debuggingClassesRootPath = new File(AgentPackagePath.getPath(), "/debugging");
+                        if (!debuggingClassesRootPath.exists()) {
+                            debuggingClassesRootPath.mkdir();
+                        }
+                    } catch (AgentPackageNotFoundException e) {
+                        logger.error(e, "Can't find the root path for creating /debugging folder.");
+                    }
+                }
+
+                File newClassFileFolder = new File(debuggingClassesRootPath, typeDescription.getPackage().getActualName().replaceAll("\\.", "/"));
+                if (!newClassFileFolder.exists()) {
+                    newClassFileFolder.mkdirs();
+                }
+                File newClassFile = new File(newClassFileFolder, typeDescription.getSimpleName() + ".class");
+                FileOutputStream fos = null;
+                try {
+                    if (newClassFile.exists()) {
+                        newClassFile.delete();
+                    }
+                    newClassFile.createNewFile();
+                    fos = new FileOutputStream(newClassFile);
+                    fos.write(dynamicType.getBytes());
+                    fos.flush();
+                } catch (IOException e) {
+                    logger.error(e, "Can't save class {} to file." + typeDescription.getActualName());
+                } finally {
+                    if (fos != null) {
+                        try {
+                            fos.close();
+                        } catch (IOException e) {
+
+                        }
+                    }
+                }
+            } catch (Throwable t) {
+                logger.error(t, "Save debugging classes fail.");
+            }
+        }
+    }
+}

--- a/apm-sniffer/apm-agent/src/main/java/org/skywalking/apm/agent/SkyWalkingAgent.java
+++ b/apm-sniffer/apm-agent/src/main/java/org/skywalking/apm/agent/SkyWalkingAgent.java
@@ -18,6 +18,8 @@
 
 package org.skywalking.apm.agent;
 
+import java.lang.instrument.Instrumentation;
+import java.util.List;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
@@ -26,10 +28,11 @@ import org.skywalking.apm.agent.core.boot.ServiceManager;
 import org.skywalking.apm.agent.core.conf.SnifferConfigInitializer;
 import org.skywalking.apm.agent.core.logging.api.ILog;
 import org.skywalking.apm.agent.core.logging.api.LogManager;
-import org.skywalking.apm.agent.core.plugin.*;
-
-import java.lang.instrument.Instrumentation;
-import java.util.List;
+import org.skywalking.apm.agent.core.plugin.AbstractClassEnhancePluginDefine;
+import org.skywalking.apm.agent.core.plugin.EnhanceContext;
+import org.skywalking.apm.agent.core.plugin.PluginBootstrap;
+import org.skywalking.apm.agent.core.plugin.PluginException;
+import org.skywalking.apm.agent.core.plugin.PluginFinder;
 
 /**
  * The main entrance of sky-waking agent,
@@ -103,6 +106,8 @@ public class SkyWalkingAgent {
                 if (logger.isDebugEnable()) {
                     logger.debug("On Transformation class {}.", typeDescription.getName());
                 }
+
+                InstrumentDebuggingClass.INSTANCE.log(typeDescription, dynamicType);
             }
 
             @Override
@@ -113,7 +118,7 @@ public class SkyWalkingAgent {
 
             @Override public void onError(String typeName, ClassLoader classLoader, JavaModule module, boolean loaded,
                 Throwable throwable) {
-                logger.error("Failed to enhance class " + typeName, throwable);
+                logger.error("Enhance class " + typeName + " error.", throwable);
             }
 
             @Override

--- a/apm-sniffer/config/agent.config
+++ b/apm-sniffer/config/agent.config
@@ -12,8 +12,8 @@ agent.application_code=Your_ApplicationName
 # Ignore the segments if their operation names start with these suffix.
 # agent.ignore_suffix=.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg
 
-# If true, skywalking agent will save all instrumented classes files. And you can send them to skywalking team,
-# in order to resolve compatible problem.
+# If true, skywalking agent will save all instrumented classes files in `/debugging` folder.
+# Skywalking team may ask for these files in order to resolve compatible problem.
 # agent.is_open_debugging_class = true
 
 # Server addresses.

--- a/apm-sniffer/config/agent.config
+++ b/apm-sniffer/config/agent.config
@@ -12,6 +12,10 @@ agent.application_code=Your_ApplicationName
 # Ignore the segments if their operation names start with these suffix.
 # agent.ignore_suffix=.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg
 
+# If true, skywalking agent will save all instrumented classes files. And you can send them to skywalking team,
+# in order to resolve compatible problem.
+# agent.is_open_debugging_class = true
+
 # Server addresses.
 # Mapping to `agent_server/jetty/port` in `config/application.yml` of Collector.
 # Examples：

--- a/docs/cn/Deploy-skywalking-agent-CN.md
+++ b/docs/cn/Deploy-skywalking-agent-CN.md
@@ -38,6 +38,10 @@ agent.application_code=Your_ApplicationName
 # 默认配置如下
 # agent.ignore_suffix=.jpg,.jpeg,.js,.css,.png,.bmp,.gif,.ico,.mp3,.mp4,.html,.svg
 
+# 探针调试开关，如果设置为true，探针会将所有操作字节码的类输出到/debugging目录下
+# skywalking团队可能在调试，需要此文件
+# agent.is_open_debugging_class = true
+
 # 对应Collector的config/application.yml配置文件中 agent_server/jetty/port 配置内容
 # 例如：
 # 单节点配置：SERVERS="127.0.0.1:8080" 


### PR DESCRIPTION
This pull request will not influence any feature or known bug. For helping Skywalking team to find which happened in an instrumented class, I provide a config, named `agent.is_open_debugging_class`, which is a true/false config, default false. 

If true, skywalking agent will save all instrumented classes files. And you can send them to skywalking team, in order to resolve compatible problem.