### PR TITLE
Make sure don't miss the provider(module)

### DIFF
--- a/apm-collector/apm-collector-core/src/main/java/org/skywalking/apm/collector/core/module/BootstrapFlow.java
+++ b/apm-collector/apm-collector-core/src/main/java/org/skywalking/apm/collector/core/module/BootstrapFlow.java
@@ -103,10 +103,12 @@ public class BootstrapFlow {
                     if (isAllRequiredModuleStarted) {
                         startupSequence.add(provider);
                         allProviders.remove(i);
+                        i--;
                     }
                 } else {
                     startupSequence.add(provider);
                     allProviders.remove(i);
+                    i--;
                 }
             }
 


### PR DESCRIPTION
Thanks to @levou , he found out a potential bug in collector startup sequence. In the prev codes, some provider may be miss, and trigger an unexpected CycleDependencyException.