### PR TITLE
Try to update gRPC 1.8.0 and netty 4.1.17

### DIFF
--- a/apm-network/pom.xml
+++ b/apm-network/pom.xml
@@ -113,7 +113,7 @@
                     <protocArtifact>com.google.protobuf:protoc:3.3.0:exe:${os.detected.classifier}
                     </protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.7.0:exe:${os.detected.classifier}
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.8.0:exe:${os.detected.classifier}
                     </pluginArtifact>
                 </configuration>
                 <executions>

--- a/apm-network/pom.xml
+++ b/apm-network/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <grpc.version>1.8.0</grpc.version>
+        <netty.version>4.1.17.Final</netty.version>
         <compiler.version>1.6</compiler.version>
     </properties>
 
@@ -40,6 +41,20 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <version>${grpc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler-proxy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -51,6 +66,21 @@
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -58,7 +88,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
+                <version>1.5.0.Final</version>
             </extension>
         </extensions>
         <plugins>

--- a/apm-network/pom.xml
+++ b/apm-network/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <grpc.version>1.7.0</grpc.version>
+        <grpc.version>1.8.0</grpc.version>
         <compiler.version>1.6</compiler.version>
     </properties>
 

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty.version>9.4.2.v20170220</jetty.version>
-        <grpc.version>1.7.0</grpc.version>
+        <grpc.version>1.8.0</grpc.version>
         <bytebuddy.version>1.7.6</bytebuddy.version>
 
         <shade.package>org.skywalking.apm.dependencies</shade.package>
@@ -50,6 +50,8 @@
         <shade.io.grpc.target>${shade.package}.${shade.io.grpc.source}</shade.io.grpc.target>
         <shade.io.netty.source>io.netty</shade.io.netty.source>
         <shade.io.netty.target>${shade.package}.${shade.io.netty.source}</shade.io.netty.target>
+        <shade.io.opencensus.source>io.opencensus</shade.io.opencensus.source>
+        <shade.io.opencensus.target>${shade.package}.${shade.io.opencensus.source}</shade.io.opencensus.target>
     </properties>
 
     <dependencies>
@@ -175,6 +177,10 @@
                                 <relocation>
                                     <pattern>${shade.io.netty.source}</pattern>
                                     <shadedPattern>${shade.io.netty.target}</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>${shade.io.opencensus.source}</pattern>
+                                    <shadedPattern>${shade.io.opencensus.target}</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>


### PR DESCRIPTION
Hi @chidaodezhongsheng 

This pull request is trying to fix your issues. You can download `fix/gRPC-1.8.0` branch, and build at local to do the tests. The gRPC 1.8.0 depends netty 4.1.16 by default, but the netty issue just fixed in 4.1.17 based on @peng-yongsheng . So I do the netty update to 4.1.17, overriding the gRPC dependencies.

But be advised, I can't reproduce the error in my laptop. After you checked, **APPROVE** this pull request as a reviewer. Otherwise, this issue won't be fixed until gRPC does.

cc @OpenSkywalking/pmc @OpenSkywalking/committer-team @OpenSkywalking/huawei-devcloud-contributor-team 