### PR TITLE
fix match failed issue

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/match/HierarchyMatch.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/skywalking/apm/agent/core/plugin/match/HierarchyMatch.java
@@ -72,7 +72,9 @@ public class HierarchyMatch implements IndirectMatch {
             matchHierarchyClass(implInterface, parentTypes);
         }
 
-        matchHierarchyClass(typeDescription.getSuperClass(), parentTypes);
+        if (typeDescription.getSuperClass() != null) {
+            matchHierarchyClass(typeDescription.getSuperClass(), parentTypes);
+        }
 
         if (parentTypes.size() == 0) {
             return true;

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/src/main/java/org/skywalking/apm/plugin/spring/concurrent/match/EitherInterfaceMatch.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/src/main/java/org/skywalking/apm/plugin/spring/concurrent/match/EitherInterfaceMatch.java
@@ -56,7 +56,10 @@ public abstract class EitherInterfaceMatch implements IndirectMatch {
             matchHierarchyClazz(generic, matchResult);
         }
 
-        matchHierarchyClazz(typeDescription.getSuperClass(), matchResult);
+        if (typeDescription.getSuperClass() != null) {
+            matchHierarchyClazz(typeDescription.getSuperClass(), matchResult);
+        }
+
         return matchResult.result();
     }
 


### PR DESCRIPTION
The `typeDescription.getSuperClass()` method return null if the `typeDescription` is an interface and it cause that the console display `NullPointException` exception.