### PR TITLE
fix match failed issue

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/src/main/java/org/skywalking/apm/plugin/spring/concurrent/match/ListenableFutureCallbackMatch.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/src/main/java/org/skywalking/apm/plugin/spring/concurrent/match/ListenableFutureCallbackMatch.java
@@ -44,7 +44,7 @@ public class ListenableFutureCallbackMatch implements IndirectMatch {
     @Override
     public ElementMatcher.Junction buildJunction() {
         return not(nameStartsWith("org.springframework")).
-            and(hasSuperType(named(LISTENABLE_FUTURE_CALLBACK_CLASS_NAME)));
+                and(hasSuperType(named(LISTENABLE_FUTURE_CALLBACK_CLASS_NAME)));
     }
 
     @Override
@@ -53,8 +53,12 @@ public class ListenableFutureCallbackMatch implements IndirectMatch {
         for (TypeDescription.Generic generic : typeDescription.getInterfaces()) {
             isMatch = isMatch || matchExactClass(generic);
         }
-
-        return isMatch || matchExactClass(typeDescription.getSuperClass());
+        
+        if (typeDescription.getSuperClass() != null) {
+            return isMatch || matchExactClass(typeDescription.getSuperClass());
+        } else {
+            return isMatch;
+        }
     }
 
     private boolean matchExactClass(TypeDescription.Generic clazz) {


### PR DESCRIPTION
The `typeDescription.getSuperClass()` method return null if the `typeDescription` is an interface and it cause that the console display NullPointException exception.