### PR TITLE
fix mysql 5.0.x plugin issue

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/ConnectionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/ConnectionInstrumentation.java
@@ -49,8 +49,6 @@ import static org.skywalking.apm.plugin.jdbc.define.Constants.SERVICE_METHOD_INT
  */
 public abstract class ConnectionInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
 
-    public static final String ENHANCE_CLASS = "com.mysql.jdbc.ConnectionImpl";
-
     @Override protected ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
         return new ConstructorInterceptPoint[0];
     }

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/ConnectionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/ConnectionInstrumentation.java
@@ -35,7 +35,6 @@ import static org.skywalking.apm.plugin.jdbc.define.Constants.PREPARE_STATEMENT_
 import static org.skywalking.apm.plugin.jdbc.define.Constants.RELEASE_SAVE_POINT_METHOD_NAME;
 import static org.skywalking.apm.plugin.jdbc.define.Constants.ROLLBACK_METHOD_NAME;
 import static org.skywalking.apm.plugin.jdbc.define.Constants.SERVICE_METHOD_INTERCEPT_CLASS;
-import static org.skywalking.apm.plugin.jdbc.mysql.define.MultiClassNameMatch.byMultiClassMatch;
 
 /**
  * {@link ConnectionInstrumentation} intercepts the following methods that the class which extend {@link
@@ -48,7 +47,7 @@ import static org.skywalking.apm.plugin.jdbc.mysql.define.MultiClassNameMatch.by
  *
  * @author zhangxin
  */
-public class ConnectionInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+public abstract class ConnectionInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
 
     public static final String ENHANCE_CLASS = "com.mysql.jdbc.ConnectionImpl";
 
@@ -114,7 +113,5 @@ public class ConnectionInstrumentation extends ClassInstanceMethodsEnhancePlugin
 
     }
 
-    @Override protected ClassMatch enhanceClass() {
-        return byMultiClassMatch(ENHANCE_CLASS, "com.mysql.cj.jdbc.ConnectionImpl", "com.mysql.jdbc.Connection");
-    }
+    @Override protected abstract ClassMatch enhanceClass();
 }

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/Mysql50ConnectionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/Mysql50ConnectionInstrumentation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+
+package org.skywalking.apm.plugin.jdbc.mysql.define;
+
+import org.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import static org.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
+
+/**
+ * {@link Mysql50ConnectionInstrumentation} interceptor the {@link com.mysql.jdbc.Connection} class in the 5.0.x verison
+ * of mysql driver jar.
+ *
+ * @author zhangxin
+ */
+public class Mysql50ConnectionInstrumentation extends ConnectionInstrumentation {
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byName("com.mysql.jdbc.Connection");
+    }
+
+    @Override protected String[] witnessClasses() {
+        return new String[] {"com.mysql.jdbc.CursorRowProvider"};
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/Mysql5xConnectionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/Mysql5xConnectionInstrumentation.java
@@ -29,7 +29,11 @@ import static org.skywalking.apm.plugin.jdbc.mysql.define.MultiClassNameMatch.by
  * @author zhangxin
  */
 public class Mysql5xConnectionInstrumentation extends ConnectionInstrumentation {
+    public static final String ENHANCE_CLASS = "com.mysql.jdbc.ConnectionImpl";
+
+    public static final String CJ_JDBC_ENHANCE_CLASS = "com.mysql.cj.jdbc.ConnectionImpl";
+
     @Override protected ClassMatch enhanceClass() {
-        return byMultiClassMatch(ENHANCE_CLASS, "com.mysql.cj.jdbc.ConnectionImpl");
+        return byMultiClassMatch(ENHANCE_CLASS, CJ_JDBC_ENHANCE_CLASS);
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/Mysql5xConnectionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/skywalking/apm/plugin/jdbc/mysql/define/Mysql5xConnectionInstrumentation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, OpenSkywalking Organization All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Project repository: https://github.com/OpenSkywalking/skywalking
+ */
+
+package org.skywalking.apm.plugin.jdbc.mysql.define;
+
+import org.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import static org.skywalking.apm.plugin.jdbc.mysql.define.MultiClassNameMatch.byMultiClassMatch;
+
+/**
+ * {@link Mysql50ConnectionInstrumentation} interceptor the {@link com.mysql.cj.jdbc.ConnectionImpl} class above the
+ * version 5.1+ of mysql jdbc driver jar.
+ *
+ * @author zhangxin
+ */
+public class Mysql5xConnectionInstrumentation extends ConnectionInstrumentation {
+    @Override protected ClassMatch enhanceClass() {
+        return byMultiClassMatch(ENHANCE_CLASS, "com.mysql.cj.jdbc.ConnectionImpl");
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/resources/skywalking-plugin.def
@@ -1,5 +1,6 @@
 mysql-5.x=org.skywalking.apm.plugin.jdbc.mysql.define.DriverInstrumentation
-mysql-5.x=org.skywalking.apm.plugin.jdbc.mysql.define.ConnectionInstrumentation
+mysql-5.x=org.skywalking.apm.plugin.jdbc.mysql.define.Mysql5xConnectionInstrumentation
+mysql-5.x=org.skywalking.apm.plugin.jdbc.mysql.define.Mysql50ConnectionInstrumentation
 mysql-5.x=org.skywalking.apm.plugin.jdbc.mysql.define.CallableInstrumentation
 mysql-5.x=org.skywalking.apm.plugin.jdbc.mysql.define.PreparedStatementInstrumentation
 mysql-5.x=org.skywalking.apm.plugin.jdbc.mysql.define.StatementInstrumentation


### PR DESCRIPTION
Fix the issue that jdbc plugin intercept `com.mysql.jdbc.Connection` failed in the 5.1 + version of mysql driver jar. because of the `com.mysql.jdbc.Connection` class is an interface in the 5.1 + version.   and I add witness class to resolve this problem